### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ for i in [0..5]
 ƒ('item2').x = 200
 ```
 
-####Contact
+#### Contact
 
 Twitter: [@andreaswah](http://twitter.com/andreaswah)
 
-####Thanks to
+#### Thanks to
 Jordan, Marc, David and Koen for early feedback!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
